### PR TITLE
Updating metric names.

### DIFF
--- a/host-alerts.yml
+++ b/host-alerts.yml
@@ -10,7 +10,7 @@ groups:
       text: |
         {{ $labels.instance }} of job {{ $labels.job }} has been down for more than 1 minute.
   - alert: LowMemory
-    expr: ((node_memory_MemFree{instance=~"$server"} / node_memory_MemTotal{instance=~"$server"})
+    expr: ((node_memory_MemFree_bytes{instance=~"$server"} / node_memory_MemTotal_bytes{instance=~"$server"})
       * 100) < 5
     for: 5m
     labels:
@@ -27,7 +27,7 @@ groups:
         of {{ $value }}.
       summary: Instance {{ $labels.instance }} CPU usage is dangerously high
   - alert: low_disk_space
-    expr: (node_filesystem_free / node_filesystem_size) * 100 < 10
+    expr: (node_filesystem_free_bytes / node_filesystem_size_bytes) * 100 < 10
     for: 5m
     annotations:
       description: This device has a disk with less than 10% free {{ $value }}.

--- a/kubernetes-alerts.yml
+++ b/kubernetes-alerts.yml
@@ -18,7 +18,7 @@ groups:
       description: Scaling down {{ $value }} node(s)
       summary: Kube Cluster Autoscaler is scaling down
   - alert: PodRestartingTooMuch
-    expr: rate(kube_pod_container_status_restarts[2m]) > 1 / (5 * 60)
+    expr: rate(kube_pod_container_status_restarts_total[2m]) > 1 / (5 * 60)
     for: 30m
     labels:
       severity: critical


### PR DESCRIPTION
Found deprecated metrics with this:

for expr in $(curl -s https://raw.githubusercontent.com/prometheus/node_exporter/master/docs/example-16-compatibility-rules.yml | grep expr | grep -oE 'node_[^ ]+'); do echo "===== $expr"; grep -rI $expr; done

Updated manually.